### PR TITLE
Bug/behat fails randomly

### DIFF
--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -63,27 +63,11 @@ class FeatureContext extends RawWordpressContext {
 	 */
 	public function iAmLoggedInWithTheNameAndThePassword( $arg1, $arg2 ) {
 
-		$this->logIn( $arg1, $arg2 );
-	}
-
-	/**
-	 * Determine if the current user is logged in or not.
-	 * Overwrites the original loggedIn to put some waiting to it.
-	 *
-	 * @return bool
-	 */
-	public function loggedIn() {
-
-		sleep(1);
-		$page = $this->getSession()->getPage();
-		// Look for a selector to determine if the user is logged in.
-		try {
-			return $page->has('css', 'body.logged-in');
-		} catch (DriverException $e) {
-			// This may fail if the user has not loaded any site yet.
+		if ( $this->loggedIn() ) {
+			$this->logOut();
+			sleep( 1 );
 		}
-
-		return false;
+		$this->logIn( $arg1, $arg2 );
 	}
 
 	/**

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -63,21 +63,17 @@ class FeatureContext extends RawWordpressContext {
 	/**
 	 * @Given I am logged in with the name :username and the password :password
 	 */
-	public function iAmLoggedInWithTheNameAndThePassword( $username, $password ) {
+	public function iAmLoggedInWithTheNameAndThePassword( $username, $password, $counter = 0 ) {
 
-		$this->visitPath( 'wp-login.php' );
-		$page = $this->getSession()->getPage();
-
-		$node = $page->findField( 'user_login' );
-		$node->setValue( '' );
-		$node->setValue( $username );
-
-		$node = $page->findField( 'user_pass' );
-		$node->setValue( '' );
-		$node->setValue( $password );
-
-		$page->findButton( 'wp-submit' )->click();
-
+		// Workaround: We loop this, since this seems to fail randomly, when we log in several times in one feature.
+		try {
+			$this->logIn( $username, $password );
+		} catch ( ExpectationException $e ) {
+			$this->iAmLoggedInWithTheNameAndThePassword( $username, $password, $counter+1 );
+			if ( 10 === $counter ) {
+				throw $e;
+			}
+		}
 	}
 
 	/**

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -2,7 +2,9 @@
 use PaulGibbs\WordpressBehatExtension\Context\RawWordpressContext;
 use PaulGibbs\WordpressBehatExtension\Context\Traits\UserAwareContextTrait;
 use PaulGibbs\WordpressBehatExtension\Context\Traits\CacheAwareContextTrait;
-use Behat\Mink\Exception\DriverException;
+
+use Behat\Mink\Exception\ExpectationException;
+use Behat\Mink\Exception\UnsupportedDriverActionException;
 
 use Behat\Behat\Context\SnippetAcceptingContext;
 use Behat\Behat\Tester\Exception\PendingException;
@@ -40,7 +42,7 @@ class FeatureContext extends RawWordpressContext {
 	 */
 	public function theInputFieldShouldContain( $arg1, $arg2 ) {
 		$this->assertSession()
-		     ->elementAttributeContains( 'css', $arg1, 'value', $arg2 );
+			 ->elementAttributeContains( 'css', $arg1, 'value', $arg2 );
 	}
 
 	/**
@@ -59,15 +61,23 @@ class FeatureContext extends RawWordpressContext {
 	}
 
 	/**
-	 * @Given I am logged in with the name :arg1 and the password :arg2
+	 * @Given I am logged in with the name :username and the password :password
 	 */
-	public function iAmLoggedInWithTheNameAndThePassword( $arg1, $arg2 ) {
+	public function iAmLoggedInWithTheNameAndThePassword( $username, $password ) {
 
-		if ( $this->loggedIn() ) {
-			$this->logOut();
-			sleep( 1 );
-		}
-		$this->logIn( $arg1, $arg2 );
+		$this->visitPath( 'wp-login.php' );
+		$page = $this->getSession()->getPage();
+
+		$node = $page->findField( 'user_login' );
+		$node->setValue( '' );
+		$node->setValue( $username );
+
+		$node = $page->findField( 'user_pass' );
+		$node->setValue( '' );
+		$node->setValue( $password );
+
+		$page->findButton( 'wp-submit' )->click();
+
 	}
 
 	/**

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -2,6 +2,7 @@
 use PaulGibbs\WordpressBehatExtension\Context\RawWordpressContext;
 use PaulGibbs\WordpressBehatExtension\Context\Traits\UserAwareContextTrait;
 use PaulGibbs\WordpressBehatExtension\Context\Traits\CacheAwareContextTrait;
+use Behat\Mink\Exception\DriverException;
 
 use Behat\Behat\Context\SnippetAcceptingContext;
 use Behat\Behat\Tester\Exception\PendingException;
@@ -63,6 +64,26 @@ class FeatureContext extends RawWordpressContext {
 	public function iAmLoggedInWithTheNameAndThePassword( $arg1, $arg2 ) {
 
 		$this->logIn( $arg1, $arg2 );
+	}
+
+	/**
+	 * Determine if the current user is logged in or not.
+	 * Overwrites the original loggedIn to put some waiting to it.
+	 *
+	 * @return bool
+	 */
+	public function loggedIn() {
+
+		sleep(1);
+		$page = $this->getSession()->getPage();
+		// Look for a selector to determine if the user is logged in.
+		try {
+			return $page->has('css', 'body.logged-in');
+		} catch (DriverException $e) {
+			// This may fail if the user has not loaded any site yet.
+		}
+
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
The tests often switch between users. The tests failed randomly, because they couldn't log in again. Probably the logout can take a bit longer and it might finish after the 2nd login. This PR logs the user out first and waits a second to login again, to give the logout process some space.